### PR TITLE
using explicit annotation, so it would work with ng-strict-di

### DIFF
--- a/angular-lock.js
+++ b/angular-lock.js
@@ -20,7 +20,7 @@
       this.options = config.options || {};
     }
 
-    this.$get = function($rootScope) {
+    this.$get = ["$rootScope", function($rootScope) {
 
       var Lock = new Auth0Lock(this.clientID, this.domain, this.options);
       var lock = {};
@@ -65,6 +65,6 @@
         })(functions[i]);
       }
       return lock;
-    }
+    }]
   }
 })();


### PR DESCRIPTION
Hi @chenkie,

Angular-lock would break the application if angular is running with strict-di mode enabled.
The problem occurred using the normal '.js', the '.min.js' has dealt it correctly.

Thanks,
Hao Yuan