### PR TITLE
Set auth0-lock dependency major version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "main": "angular-lock.js",
   "dependencies": {
     "angular": "*",
-    "auth0-lock": ">=11.0.0",
+    "auth0-lock": "^11.0.0",
     "auth0.js": "^9.0.0"
   },
   "resolutions": {


### PR DESCRIPTION
Unless you can already guarantee this version of the library works with any future major version of auth0-lock, let's make sure that it does not pick up auth0-lock v12 or later when they're out.